### PR TITLE
Fix u-go.net link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Start by installing Tensorflow along with GPU drivers (i.e. CUDA support for Nvi
 
 Get SGFs for supervised learning
 --------------------------------
-Second, find a source of SGF files. You can find 15 years of KGS high-dan games at [u-go.net](u-go.net/gamerecords/). Alternately, you can download a database of professional games from a variety of sources.
+Second, find a source of SGF files. You can find 15 years of KGS high-dan games at [u-go.net](https://u-go.net/gamerecords/). Alternately, you can download a database of professional games from a variety of sources.
 
 Preprocess SGFs
 ---------------


### PR DESCRIPTION
The current u-go.net link is a relative URL that points to https://github.com/brilee/MuGo/blob/master/u-go.net/gamerecords instead of https://u-go.net/gamerecords/.

I made this change using GitHub's inline text editor. It looks like text editor inadvertently added a newline at the end of the file.